### PR TITLE
iPhone X initial height adjustment

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -637,6 +637,12 @@ BOOL isExiting = FALSE;
     [self.webView setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
     self.webView.allowsLinkPreview = NO;
     self.webView.allowsBackForwardNavigationGestures = NO;
+	
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+   if (@available(iOS 11.0, *)) {
+	   [self.webView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+   }
+#endif
     
     
     self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the purpose of this PR?

Fixes the initial layout of this inappbrowser in iPhone X which was cutting off some of the height.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?

Tested on the iPhone X simulator 11.4

Based off of the fix in https://github.com/apache/cordova-plugin-wkwebview-engine/pull/45